### PR TITLE
Changed documentation (github.io for GH pages).

### DIFF
--- a/README
+++ b/README
@@ -19,12 +19,12 @@ A log of all of your achievements is kept locally, but you can also publish
 it to GitHub pages so you can share your achievements (and there is a rss
 feed so people can track your achievements).
 
-For example here is the project maintainer's achievements page: http://icefox.github.com/git-achievements
+For example here is the project maintainer's achievements page: http://icefox.github.io/git-achievements
 
 If you are viewing a forked version of git-achievements you want to replace icefox
 with the github user account you want to see like so:
 
-http://<username>.github.com/git-achievements
+http://<username>.github.io/git-achievements
 
 To push your achievements to GitHub first fork the project on GitHub,
 clone *your* repository and set the following config to true:
@@ -39,7 +39,7 @@ Install
 -------
 Add git-achievements to your path and alias git to git-achievements
 
-For example add the following to the end of your ~/.bash_profile
+For example put git-achievements under ~/git/git-achievements/ and add the following to the end of your ~/.bash_profile
 
 export PATH="$PATH:~/git/git-achievements"
 alias git="git-achievements"


### PR DESCRIPTION
Hi again,

changed the documentation, taking into concern that github.com for GH pages is deprecated and github.io should be used instead. 

Furthermore explained the installation in more detail.

Regards,

Karsten
